### PR TITLE
Fix for syntax error while installation

### DIFF
--- a/indexedproperty/__init__.py
+++ b/indexedproperty/__init__.py
@@ -238,7 +238,7 @@ class IndexedProperty:
     # addmethod will not allow you to create a method from illegalmethods.
     illegalmethods = ('__getitem__', '__setitem__', '__delitem__')
     
-    def __init__(self, getter=None, name=None, doc=None, *, tdict=None, **kwargs):
+    def __init__(self, getter=None, name=None, doc=None, tdict=None, **kwargs):
         """
         Create a new IndexedProperty.
         


### PR DESCRIPTION
Fix for syntax error while installation (issue #1 ):
```
$ python setup.py build
Traceback (most recent call last):
  File "setup.py", line 7, in <module>
    from indexedproperty import __version__
  File "/mnt/sda2/My Documents/Visual Studio 2005/Projects/indexedproperty/indexedproperty/__init__.py", line 241
    def __init__(self, getter=None, name=None, doc=None, *, tdict=None, **kwargs):
                                                          ^
SyntaxError: invalid syntax
```